### PR TITLE
Feature/punto dos calculo plantas exterior interior

### DIFF
--- a/MISW-4104-vivero-el-otonio/src/app/plantas/plantas-list/plantas-list.component.html
+++ b/MISW-4104-vivero-el-otonio/src/app/plantas/plantas-list/plantas-list.component.html
@@ -17,4 +17,6 @@
       </tr>
     </tbody>
   </table>
+  <div>Total plantas de interior: {{plantasInterior}}</div>
+  <div>Total plantas de exterior: {{plantasExterior}}</div>
 </div>

--- a/MISW-4104-vivero-el-otonio/src/app/plantas/plantas-list/plantas-list.component.ts
+++ b/MISW-4104-vivero-el-otonio/src/app/plantas/plantas-list/plantas-list.component.ts
@@ -10,14 +10,20 @@ import { PlantaService } from '../planta.service';
 export class PlantasListComponent implements OnInit {
 
   plantas: Array<Planta> = [];
+  plantasInterior: number = 0;
+  plantasExterior: number = 0;
 
   constructor(private plantaService: PlantaService) { }
 
   getPlantas(): void {
     this.plantaService.getPlantas().subscribe((plantas) => {
       this.plantas = plantas;
+      this.plantasInterior = plantas.filter(planta => planta.tipo === "Interior").length;
+      this.plantasExterior = plantas.filter(planta => planta.tipo === "Exterior").length;
     });
   }
+
+
 
   ngOnInit() {
     this.getPlantas();


### PR DESCRIPTION
Feature/punto dos calculo plantas exterior interior

Punto No. 2 (10%)

Modifique el componente de listar para incluir dos líneas que muestren el total de plantas por tipo proporcionados por el listado (el vivero tiene plantas de interior y de exterior). Este número debe ser calculado ya que no se conoce a priori. 

El resultado debe verse lo más parecido a la Fig. 2: 
